### PR TITLE
Feature/build essential required

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Requirements
 
 Debian Wheezy.
 
-Warning: This role will install **build-essential** if it isn't already present.  Some people consider this a security
-risk.  If you're one of them,  you should remove build-essential in a role that runs later, or manually.
+Warning: This role will install **build-essential** if it isn't already present.
+Some people consider this a security risk.  If you're one of them,  you should 
+remove build-essential in a role that runs later, or manually.
 
 
 Role Variables

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Install and start beanstalkd
 Requirements
 ------------
 
-Debian Wheezy with the package **build-essential** installed.
+Debian Wheezy.
+
+Warning: This role will install **build-essential** if it isn't already present.  Some people consider this a security
+risk.  If you're one of them,  you should remove build-essential in a role that runs later, or manually.
 
 
 Role Variables

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Discover if there is already a version of beanstalkd installed.
   shell: which beanstalkd > /dev/null && beanstalkd -v | cut -d' ' -f2
   changed_when: False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Ensure build-essential package is installed
+  apt: pkg=build-essential state=present
+
 - name: Get tarfile
   command: wget https://github.com/kr/beanstalkd/archive/v{{ beanstalkd_version }}.tar.gz -q -O /tmp/beanstalkd.tar.gz creates=/tmp/beanstalkd.tar.gz
 


### PR DESCRIPTION
One more change I had in my local version.

This is currently the only role that I'm using that requires build tools, so we may as well let ansible ensure they're installed.

I am a little ambivalent about it, as I don't like having gcc and friends sitting around on production systems.  But for now I'm allowing it.  I suppose I could have another role that ensures the build tools are removed at the end.
