### PR TITLE
Switch to unarchive module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
   when: installed_beanstalkd_version.stdout != beanstalkd_version
 
 - name: Unarchive.
-  command: tar -zxvf /tmp/beanstalkd-{{ beanstalkd_version }}.tar.gz chdir=/tmp creates=/tmp/beanstalkd-{{ beanstalkd_version }}
+  unarchive: remote_src=true src=/tmp/beanstalkd-{{ beanstalkd_version }}.tar.gz dest=/tmp
   when: installed_beanstalkd_version.stdout != beanstalkd_version
 
 - name: Make.


### PR DESCRIPTION
Using this module sends out a warning. This PR will fix that warning by switching to the ansible unarchive module instead of executing a tar command.
```
[WARNING]: Consider using the unarchive module rather than running tar.  If
you need to use command because unarchive is insufficient you can add
warn=False to this command task or set command_warnings=False in ansible.cfg to
get rid of this message.
```
